### PR TITLE
[FEAT]스터디글 모든 param 조회 API

### DIFF
--- a/src/main/java/com/example/demo/controller/StudyController.java
+++ b/src/main/java/com/example/demo/controller/StudyController.java
@@ -39,9 +39,8 @@ public class StudyController {
     public ResponseEntity<ResponseMessage> getStudiesByKeyword(@RequestParam(required = false) String keyword, @RequestParam(required = false) String location, @RequestParam(required = false) String category){
         //2글자 이상: 프론트에서 컷 + 해시태그와 키워드 동시에 적용된 검색도 가능해야함
         //여러개의 request param이 동시에 올 수 있음 -> 하나로 합치기 -> null이 아닌 값에 대해서만 검색 처리를 해야하는데 이걸 어떻게 효율적으로 할것인가....
-        //1. 각 param별로 검색 결과 list를 찾아서 controller 단에 저장
-        // (category의 경우 service에서 %2C 또는 , 기준으로 잘라서 값 찾기 -> 전체 값들에 대해 or query 문으로 list 반환 개수에 따라 쿼리문이 달라지게 설계할 수 있는지)
-        //2.모든 list들을 중복되는 부분 제외 하나로 합쳐서 response message에 담아서 반환 (등록된 스터디글이 없으면 없다는 메세지 반환)
+        //studyStatus가 1이어야 하는건 필수 where 조건
+
         if(keyword==null&&location==null&&category==null){ //쿼리 파라미터가 없으면 전체 스터디글 조회
             List<StudyPost> studyPostList=studyPostService.getAllStudyPosts();
             if(studyPostList.isEmpty()){
@@ -50,25 +49,12 @@ public class StudyController {
             return new ResponseEntity<>(ResponseMessage.withData(200,"전체 스터디글 조회 성공",studyPostList), HttpStatus.OK);
         }
 
-        List<StudyPost> keywordPosts=null; // 파라미터가 없다면 null
-        List<StudyPost> categoryPosts=null;
 
-        if(keyword!=null){ // 파라미터가 있는 애들에 대해서만 조회
-            keywordPosts=studyPostService.getStudyPostsByKeyword(keyword); // 검색어 기반 쿼리에 대한 결과 (검색결과 없으면 empty list)
+        List<StudyPost> filteredPosts=studyPostService.getStudyPostsWithFilter(category,keyword,location);
+        if(filteredPosts.isEmpty()){
+            return new ResponseEntity<>(new ResponseMessage(200,"조건에 맞는 스터디글이 없습니다."),HttpStatus.OK);
         }
-        if(category!=null){
-            categoryPosts=studyPostService.getStudyPostsByCategory(category);
-            if(categoryPosts.isEmpty()){
-                return new ResponseEntity<>(new ResponseMessage(200,"\""+category+"\" 기반 스터디글이 존재하지 않습니다."), HttpStatus.OK);
-            }else{
-                return new ResponseEntity<>(ResponseMessage.withData(200,"\""+category+"\" 기반 스터디글 조회 성공",categoryPosts), HttpStatus.OK);
-            }
-
-        }
-
-
-
-        return new ResponseEntity<>(ResponseMessage.withData(400,"\""+category+"\" 기반 스터디글 조회 성공",categoryPosts), HttpStatus.OK);
+        return new ResponseEntity<>(ResponseMessage.withData(400,"스터디글 조회 성공",filteredPosts), HttpStatus.OK);
     }
 
     @PostMapping("/studies")

--- a/src/main/java/com/example/demo/repository/StudyPostRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/StudyPostRepositoryCustom.java
@@ -14,6 +14,6 @@ public interface StudyPostRepositoryCustom {
 //    List<StudyPost> findPostsByContentKeywords(Set<String> keywords);
     //지역 기반 -> 지역 조회 시 -> 지역은 하나만 검색 -> jpa repository 로 뺴두기
     //카테고리 기반 -> 카테고리 조회 시 -> 카테고리가 몇개가 들어올 지 모르므로 동적쿼리?
-    List<StudyPost> findPostsByCategory(String[] categories);
+    List<StudyPost> findPostsByTest(String[] categories, String[] keywords, String location);
 
 }

--- a/src/main/java/com/example/demo/repository/StudyPostRepositoryCustomImpl.java
+++ b/src/main/java/com/example/demo/repository/StudyPostRepositoryCustomImpl.java
@@ -1,40 +1,63 @@
 package com.example.demo.repository;
 
 import com.example.demo.domain.StudyPost;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-import javax.persistence.criteria.*;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+
+import static com.example.demo.domain.QStudyPost.studyPost;
 
 @Repository
 @AllArgsConstructor
 public class StudyPostRepositoryCustomImpl implements StudyPostRepositoryCustom{
-    @PersistenceContext
-    private final EntityManager em;
+    private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<StudyPost> findPostsByCategory(String[] categories) { //카테고리가 몇 개가 넘어올지 모르는 상황에서 수행할 수 있는 동적쿼리
-        CriteriaBuilder cb=em.getCriteriaBuilder();
-        CriteriaQuery<StudyPost> query=cb.createQuery(StudyPost.class);
-        Root<StudyPost> post=query.from(StudyPost.class);
+    public List<StudyPost> findPostsByTest(String[] categories, String[] keywords, String location) {
+        BooleanBuilder booleanBuilder=new BooleanBuilder();
+        //모든 categories에 대해 or조건을 더해준다
+        List<StudyPost> postList = jpaQueryFactory
+                .selectFrom(studyPost)
+                .where(predicate(categories, keywords, location))
+                .fetch();
 
-        Path<String> categoryPath=post.get("studyCategoryName"); // StudyPost 엔티티의 studyCategoryName 필드를 기반으로 조건 검색
-        List<Predicate> predicates=new ArrayList<>();
+        return postList; // 조회된게 없으면 empty list가 return 됨
 
-        for(String category:categories){
-            System.out.println("category = " + category);
-            predicates.add(cb.equal(categoryPath,category)); // 모든 선택된 categories 에 대해 조건 탐색을 적용하겠다는 것
-        }
-
-        query.select(post).where(cb.or(predicates.toArray(new Predicate[predicates.size()]))); //StudyPost 엔티티에 대해 위의 equal 조건을 걸어 select 쿼리,
-        //모든 categories 중에 하나만 매칭해도 되는 것이므로 or을 적용
-
-        return em.createQuery(query).getResultList();
     }
+
+    private BooleanBuilder predicate(String[] categories, String[] keywords, String location){
+        BooleanBuilder builder=new BooleanBuilder();
+        if(categories!=null){
+            builder.and(checkCategory(categories));
+        }
+        if(keywords!=null){
+            builder.and(checkKeyword(keywords));
+        }
+        if(location!=null){
+            builder.and(studyPost.studyLocation.eq(location));
+        }
+        return builder.and(studyPost.studyStatus.eq(1));
+    }
+
+    private BooleanBuilder checkCategory(String[] categories){
+        BooleanBuilder booleanBuilder=new BooleanBuilder();
+        for(String category:categories){
+            booleanBuilder.or(studyPost.studyCategoryName.eq(category));
+        }
+        return booleanBuilder;
+    }
+
+    private BooleanBuilder checkKeyword(String[] keywords){
+        BooleanBuilder booleanBuilder=new BooleanBuilder();
+        for(String keyword:keywords){
+            booleanBuilder.or(studyPost.studyContent.contains(keyword));
+            booleanBuilder.or(studyPost.studyTitle.contains(keyword)); // 이게 맞냐,,,,
+        }
+        return booleanBuilder;
+    }
+
+
 }

--- a/src/main/java/com/example/demo/service/StudyPostService.java
+++ b/src/main/java/com/example/demo/service/StudyPostService.java
@@ -57,43 +57,16 @@ public class StudyPostService {
         return studyPosts;
     }
 
-    public List<StudyPost> getStudyPostsByKeyword(String originKeyword){ // 만약 띄어쓰기가 들어온다면 띄어쓰기별로 다른 단어로 검색
-        if(originKeyword==null){ // 해당 키워드 파라미터를 검색에 사용하지 않은 경우 null을 return
-            return null;
+    public List<StudyPost> getStudyPostsWithFilter(String originCategories, String originKeywords, String location){
+        String[] categories=null;
+        String[] keywords=null;
+        if(originCategories!=null){
+            categories=originCategories.split(",");
         }
-        //keyword를 포함한 내용에 대한 검색 결과 return -> 검색에는 contains 또는 indexOf 사용 (indexOf는 내부에서 contains가 호출됨)
-        String[] keywords=originKeyword.split(" ");
-        //만약 " "가 없다면 그냥 한 단어만 들어가겠죠,,,? 생기는 단어 개수에 따라서 다르게 결과를 찾으려면 이중포문 돌리나? LIKE 쿼리문을 쓰는게 낫나?
-        List<StudyPost> allPosts=getAllStudyPosts();
-        List<StudyPost> keywordPosts=new ArrayList<>();
-        if(allPosts.isEmpty()){
-            return allPosts;
+        if(originKeywords!=null){
+            keywords=originKeywords.split(" ");
         }
-        //이중포문,,, 보다는 그냥 단일포문을 쓰는게 낫겠지?? 뭐 게시글이 몇백개가 되면 안되니까
-        for(String keyword:keywords){
-            for(StudyPost post:allPosts){
-//                System.out.println("post title: "+post.getStudyTitle());
-                if(post.getStudyTitle().contains(keyword)||post.getStudyContent().contains(keyword)){
-                    if(!keywordPosts.contains(post)){
-                        keywordPosts.add(post);
-                    }
-                }
-            }
-        }
-
-        return keywordPosts;
-    }
-
-    public List<StudyPost> getStudyPostsByCategory(String originCategories){
-        String[] categories=originCategories.split(",");
-        List<StudyPost> list=studyPostRepository.findPostsByCategory(categories);
-        List<StudyPost> categoryList=new ArrayList<>();
-        for(StudyPost post:list){
-            if(post.getStudyStatus()==1){
-                categoryList.add(post);
-            }
-        }
-        return categoryList; // 검색결과가 없으면 empty list가, 결과가 있으면 내용이 담긴 list가 반환됨
+        return studyPostRepository.findPostsByTest(categories,keywords,location);
     }
 
 }


### PR DESCRIPTION
- **이게 맞나요?**
1. 검색어 기반 조회 
검색어가 띄어쓰기로 들어올 때 ex) 스프링 JPA
스프링 OR JPA 조건으로 검색 (인프런이 이런 방식으로 되는 듯 해서 따라해 봤어요)
2. 검색어, 카테고리, 위치 중 2개 이상이 겹쳐서 검색이 들어올 때 ex) keyword='스프링%20JPA'&category='백엔드%2C스프링'
(제목+내용 둘 중 하나가 contains (스프링 OR JPA)) AND (카테고리 equals (백엔드 OR 스프링) 
=> 즉 중첩필터링이 생기면 AND로 두 가지 조건을 다 만족하는 결과물만 찾아서 반환
---
- **물어볼것!!**
스터디글은 검색어를 제목 + 본문으로 하는게 나을 듯 해서 요렇게 해봤는데 괜찮은 것 같나요??