### PR TITLE
[FEAT] 강의 좋아요 등록/취소 API

### DIFF
--- a/src/main/java/com/example/demo/controller/LectureController.java
+++ b/src/main/java/com/example/demo/controller/LectureController.java
@@ -2,10 +2,7 @@ package com.example.demo.controller;
 import com.example.demo.domain.*;
 import com.example.demo.dto.*;
 import com.example.demo.security.UserDetailsServiceImpl;
-import com.example.demo.service.HashtagService;
-import com.example.demo.service.LectureService;
-import com.example.demo.service.ReviewHashtagService;
-import com.example.demo.service.ReviewService;
+import com.example.demo.service.*;
 import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -29,12 +26,13 @@ public class LectureController {
     private final UserDetailsServiceImpl userDetailsService;
     private final HashtagService hashtagService;
     private final ReviewHashtagService reviewHashtagService;
+    private final LikeService likeService;
     private final EntityManager em;
 
     @GetMapping("")
     public ResponseEntity<ResponseMessage> getAllLectures() {
         List<Lecture> lectures=lectureService.getAllLectures();
-        return new ResponseEntity<>(ResponseMessage.withData(200, "강의를 조회했습니다", lectures), HttpStatus.OK);
+        return new ResponseEntity<>(ResponseMessage.withData(200, "모든 강의를 조회했습니다", lectures), HttpStatus.OK);
     }
 
     @GetMapping("/{lectureId}") // 강의글 상세 조회
@@ -47,15 +45,30 @@ public class LectureController {
         return new ResponseEntity<>(new ResponseMessage(404, "해당하는 강의가 없습니다"), HttpStatus.NOT_FOUND);
     }
 
-//    @PostMapping("/{lectureId}/likes") // 강의글 좋아요
-//    public ResponseEntity<ResponseMessage> createLike(@PathVariable("lectureId") Long lectureId) {
-//        Lecture lecture = lectureService.findById(lectureId);
-//        if(lecture != null) {// 강의정보가 있는 경우만
-////            LectureResponse lectureResponse = lectureService.
-//            return new ResponseEntity<>(ResponseMessage.withData(200, "강의를 조회했습니다", lectureResponse), HttpStatus.OK);
-//        }
-//        return new ResponseEntity<>(new ResponseMessage(404, "해당하는 강의가 없습니다"), HttpStatus.NOT_FOUND);
-//    }
+    @PostMapping("/{lectureId}/likes") // 강의글 좋아요
+    public ResponseEntity<ResponseMessage> createLike(@PathVariable("lectureId") Long lectureId, Principal principal) {
+        // 현재로그인한 사용자 아이디 가져오기
+        String email = principal.getName();
+        User user = userDetailsService.findUserByEmail(email);
+
+        Lecture lecture = lectureService.findById(lectureId);
+        if(lecture!=null) {// 강의정보가 있는 경우
+            Like existedLike = likeService.findLikeByLectureAndUser(lecture, user);
+            if(existedLike!=null) { // 좋아요가 존재하는 경우
+                int status = likeService.changeLikeStatus(existedLike, existedLike.getLikeStatus());
+                if(status==1)
+                    return new ResponseEntity<>(new ResponseMessage(200, "좋아요 재등록 성공"), HttpStatus.OK);
+                else
+                    return new ResponseEntity<>(new ResponseMessage(200, "좋아요 취소 성공"), HttpStatus.OK);
+            }
+            else {// 좋아요 처음 누른 경우
+                Like like = new Like(lecture, user);
+                likeService.saveLike(like);
+                return new ResponseEntity<>(new ResponseMessage(201, "좋아요 등록 성공"), HttpStatus.CREATED);
+            }
+        }
+        return new ResponseEntity<>(new ResponseMessage(404, "해당하는 강의가 없습니다"), HttpStatus.NOT_FOUND);
+    }
 
     @PostMapping("") // 강의 등록
     public ResponseEntity<ResponseMessage> createLecture(@RequestBody LectureDto lectureDto, Principal principal) {
@@ -120,7 +133,6 @@ public class LectureController {
     public ResponseEntity<ResponseMessage> checkLectureUrl(@RequestBody UrlCheckDto urlCheckDto){
         String lectureUrl = urlCheckDto.getLectureUrl();
         Lecture lecture = lectureService.findByUrl(lectureUrl);
-//        System.out.println("lecture = " + lecture); // 제목, 강의자, 사이트명, 이미지 url
         if(lecture!=null)// 중복링크가 있으면
             return new ResponseEntity<>(ResponseMessage.withData(200, "중복된 링크가 존재합니다.", lecture), HttpStatus.OK);
         return new ResponseEntity<>(new ResponseMessage(200, "중복된 링크가 없습니다."), HttpStatus.OK);

--- a/src/main/java/com/example/demo/controller/ReviewController.java
+++ b/src/main/java/com/example/demo/controller/ReviewController.java
@@ -41,4 +41,12 @@ public class ReviewController {
 
         return new ResponseEntity<>(new ResponseMessage(201, "강의 리뷰가 등록되었습니다."), HttpStatus.CREATED);
     }
+
+    @PostMapping("/{reviewId}/reports") // 리뷰 신고
+    public ResponseEntity<ResponseMessage> createReport(@RequestBody LectureDto lectureDto, Principal principal) {
+
+
+        return new ResponseEntity<>(new ResponseMessage(201, "강의 리뷰가 신고되었습니다."), HttpStatus.CREATED);
+    }
+
 }

--- a/src/main/java/com/example/demo/controller/StudyController.java
+++ b/src/main/java/com/example/demo/controller/StudyController.java
@@ -161,18 +161,18 @@ public class StudyController {
             like =new Like(user,0); //스터디글은 0번 division
             like.setStudyPost(post);
             em.persist(like);
-            likeService.saveInterest(like);
+            likeService.saveLike(like);
 
             return new ResponseEntity<>(new ResponseMessage(201,studyId+"번 스터디글 좋아요 등록 성공"),HttpStatus.CREATED); // 아놕 왜 좋아요 누른 post 정보가 같이 안보내질까,,, 안보내줘도 되나??
         }else if(like.getLikeStatus()==0){
             //좋아요 누른 데이터가 있는데 좋아요가 취소된 상태라면 다시 좋아요 설정
             like.setLikeStatus(1);
-            likeService.saveInterest(like);
+            likeService.saveLike(like);
             return new ResponseEntity<>(new ResponseMessage(200,studyId+"번 스터디글 좋아요로 상태 변경 성공"),HttpStatus.OK);
         }else{
             //좋아요 누른 데이터가 있는데 좋아요가 눌려있는 상태 -> 좋아요를 취소해줘야함
             like.setLikeStatus(0);
-            likeService.saveInterest(like);
+            likeService.saveLike(like);
             return new ResponseEntity<>(new ResponseMessage(200,studyId+"번 스터디글 좋아요 취소 성공"),HttpStatus.OK);
         }
 

--- a/src/main/java/com/example/demo/domain/Lecture.java
+++ b/src/main/java/com/example/demo/domain/Lecture.java
@@ -22,7 +22,7 @@ public class Lecture {
     private long lectureId;
 
     @ManyToOne(fetch = FetchType.EAGER, targetEntity = User.class)
-    @JoinColumn(name="user_id")
+    @JoinColumn(name="userId")
     @JsonBackReference
     private User user;
 
@@ -50,6 +50,11 @@ public class Lecture {
     @OneToMany(mappedBy = "lecture", targetEntity = Review.class)
     @JsonManagedReference
     private List<Review> reviews =new ArrayList<>();
+
+    // lecture : like = 1:N
+    @OneToMany(mappedBy = "lecture", targetEntity = Like.class)
+    @JsonManagedReference
+    private List<Like> likes =new ArrayList<>();
 
     @Builder
     public Lecture(String lectureTitle, String lecturer, String siteName, String lectureUrl, String thumbnailUrl) {

--- a/src/main/java/com/example/demo/domain/Like.java
+++ b/src/main/java/com/example/demo/domain/Like.java
@@ -1,6 +1,7 @@
 package com.example.demo.domain;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.querydsl.core.types.EntityPath;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -29,21 +30,26 @@ public class Like {
     @JoinColumn(name = "studyPostId")
     private StudyPost studyPost;
 
+    @ManyToOne(fetch = FetchType.EAGER,targetEntity = Lecture.class)
+    @JsonBackReference
+    @JoinColumn(name = "lectureId")
+    private Lecture lecture;
+
     //한 명의 사용자가 여러개의 관심글 등록 -> 관심글이 M, 주인
     @ManyToOne(fetch = FetchType.EAGER, targetEntity = User.class)
     @JsonBackReference
     @JoinColumn(name = "userId")
     private User user;
 
-    // Lecture:Like=1:N
-    @ManyToOne(fetch = FetchType.EAGER, targetEntity = Lecture.class)
-    @JsonBackReference
-    @JoinColumn(name = "userId")
-    private Like like;
-
     @Builder
     public Like(User user, Integer division){
         this.targetDivision=division;
         this.user=user;
+    }
+
+    @Builder
+    public Like(Lecture lecture, User user) {
+        this.lecture = lecture;
+        this.user = user;
     }
 }

--- a/src/main/java/com/example/demo/dto/LectureResponse.java
+++ b/src/main/java/com/example/demo/dto/LectureResponse.java
@@ -16,6 +16,6 @@ public class LectureResponse {
     private double avgRate; // 별점 평균
     private List<String> hashtags; // 해시태그 가장 많은 3개 리스트
     private int reviewCnt; // 리뷰 개수
-    // 좋아요 개수
+    private int likeCnt; // 좋아요 개수
     private List<ReviewOnlyDto> reviews; // 강의 리뷰
 }

--- a/src/main/java/com/example/demo/dto/ReviewOnlyDto.java
+++ b/src/main/java/com/example/demo/dto/ReviewOnlyDto.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 public class ReviewOnlyDto {
+    private String nickname;
     private long reviewId;
     private int rate;
     private String commentTitle;

--- a/src/main/java/com/example/demo/repository/CustomLikeRepository.java
+++ b/src/main/java/com/example/demo/repository/CustomLikeRepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.repository;
+
+import com.example.demo.domain.Lecture;
+import com.example.demo.domain.Like;
+
+import java.util.List;
+
+public interface CustomLikeRepository {
+    int updateLikeStatus(Like like, int likeStatus);
+    List<Like> findLikeByLecture(Lecture lecture); // 강의글 좋아요 가져오기
+}

--- a/src/main/java/com/example/demo/repository/CustomLikeRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/CustomLikeRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.example.demo.repository;
+import com.example.demo.domain.Lecture;
+import com.example.demo.domain.Like;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.example.demo.domain.QLike.like;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomLikeRepositoryImpl implements CustomLikeRepository{
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public int updateLikeStatus(Like likes, int likeStatus){
+        jpaQueryFactory
+                .update(like)
+                .set(like.likeStatus, likeStatus)
+                .where(like.likeId.eq(likes.getLikeId()))
+                .execute();
+        return likeStatus;
+    }
+
+    @Override
+    public List<Like> findLikeByLecture(Lecture lecture) {
+        return jpaQueryFactory
+                .selectFrom(like)
+                .where(like.likeStatus.eq(1))
+                .fetch();
+    }
+}

--- a/src/main/java/com/example/demo/repository/LikeRepository.java
+++ b/src/main/java/com/example/demo/repository/LikeRepository.java
@@ -1,5 +1,6 @@
 package com.example.demo.repository;
 
+import com.example.demo.domain.Lecture;
 import com.example.demo.domain.Like;
 import com.example.demo.domain.StudyPost;
 import com.example.demo.domain.User;
@@ -7,9 +8,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
-public interface LikeRepository extends JpaRepository<Like, Long> {
+public interface LikeRepository extends JpaRepository<Like, Long>, CustomLikeRepository {
     List<Like> findAllLikeByUser(User user); // user기반으로 모든 관심글 찾아오기
     List<Like> findAllLikeByStudyPost(StudyPost post); //한 스터디글에 대한 모든 좋아요 정보 가져오기
+    Optional<Like> findLikeByLectureAndUser(Lecture lecture, User user);
 }

--- a/src/main/java/com/example/demo/service/LectureService.java
+++ b/src/main/java/com/example/demo/service/LectureService.java
@@ -1,15 +1,9 @@
 package com.example.demo.service;
 
-import com.example.demo.domain.Hashtag;
-import com.example.demo.domain.Lecture;
-import com.example.demo.domain.Review;
-import com.example.demo.domain.ReviewHashtag;
+import com.example.demo.domain.*;
 import com.example.demo.dto.LectureResponse;
 import com.example.demo.dto.ReviewOnlyDto;
-import com.example.demo.repository.HashtagRepository;
-import com.example.demo.repository.LectureRepository;
-import com.example.demo.repository.ReviewHashtagRepository;
-import com.example.demo.repository.ReviewRepository;
+import com.example.demo.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
@@ -25,6 +19,7 @@ public class LectureService {
     private final ReviewRepository reviewRepository;
     private final ReviewHashtagRepository reviewHashtagRepository;
     private final HashtagRepository hashtagRepository;
+    private final LikeRepository likeRepository;
 
     public long saveLecture(Lecture lecture){
         Lecture savedLecture = lectureRepository.save(lecture);
@@ -34,7 +29,6 @@ public class LectureService {
     // 전체 강의 조회
     public List<Lecture> getAllLectures (){
         List<Lecture> lectures = lectureRepository.findAll();
-        System.out.println("lectures.size() = " + lectures.size());
         return lectures!=null?lectures:Collections.emptyList();
     }
 
@@ -43,41 +37,16 @@ public class LectureService {
         return lecture.orElse(null);
     }
 
-    // 특정 강의 조회
-    public LectureResponse getLecture(long lectureId){
-        LectureResponse lectureResponse = new LectureResponse();
-        Optional<Lecture> optionalLecture = lectureRepository.findById(lectureId); // lecture 데이터 가져와서
-        if(optionalLecture.isEmpty())
-            return lectureResponse;
-        Lecture lecture = optionalLecture.get();
-//        LectureOnlyDto lectureOnlyDto = new LectureOnlyDto(); // 원본객체 복사할 때 사용
-//        BeanUtils.copyProperties(lecture, lectureOnlyDto,"reviews", "user"); // 원본 객체, 복사 대상 객체
-        lectureResponse.setLectureId(lecture.getLectureId());
-        lectureResponse.setLectureTitle(lecture.getLectureTitle());
-        lectureResponse.setLecturer(lecture.getLecturer());
-        lectureResponse.setSiteName(lecture.getSiteName());
-        lectureResponse.setLectureUrl(lecture.getLectureUrl());
-        lectureResponse.setThumbnailUrl(lecture.getThumbnailUrl());
-
+    // 특정 Lecture에 해당하는 해시태그 상위 3개 가져오는 함수
+    public List<String> getBestHashtags(Lecture lecture){
         List<Review> reviews = reviewRepository.findByLecture(lecture); // lecture 를 갖고 reviews 에 있는 모든 데이터 가져오기
-        int reviewCnt = reviews.size();
-        lectureResponse.setReviewCnt(reviewCnt); // 리뷰 개수 세팅
-
-        int totalRate=0;
-        List<ReviewOnlyDto> reviewOnlyDtos = new ArrayList<>();
         Map<Long, Integer> hashtagCnt = new HashMap<>(); // 해시태그 상위 3개 찾기 위해서
         for(int i=0;i<reviews.size();i++){ // 특정 강의에 해당하는 리뷰들을 찾기 위해서
-            ReviewOnlyDto reviewOnlyDto = new ReviewOnlyDto();
-            BeanUtils.copyProperties(reviews.get(i), reviewOnlyDto,"reviewHashtags"); // 원본 객체, 복사 대상 객체
-            reviewOnlyDtos.add(reviewOnlyDto);
-
-            totalRate += reviews.get(i).getRate();
             List<ReviewHashtag> reviewHashtags = reviewHashtagRepository.findByReview(reviews.get(i));
 
             for(int j=0;j<reviewHashtags.size();j++){
                 long hashtagId = reviewHashtags.get(j).getHashtag().getHashtagId();
-                // 이미 키 값이 존재하면 해당 value + 1
-                if(hashtagCnt.containsKey(hashtagId)){
+                if(hashtagCnt.containsKey(hashtagId)){                 // 이미 키 값이 존재하면 해당 value + 1
                     int cnt = hashtagCnt.get(hashtagId);
                     hashtagCnt.put(hashtagId, cnt+1);
                 }
@@ -86,7 +55,6 @@ public class LectureService {
                 }
             }
         }
-        lectureResponse.setReviews(reviewOnlyDtos);
 
         // hashmap 내림차순 정렬 후 3개까지만 자르기
         List<Map.Entry<Long, Integer>> entryList = new LinkedList<>(hashtagCnt.entrySet());
@@ -101,13 +69,46 @@ public class LectureService {
             hashtags.add(hashtagName);
             limit++;
         }
-        lectureResponse.setHashtags(hashtags);
-        lectureResponse.setAvgRate(totalRate/reviews.size()); // 평균 점수 계산
-
-        return lectureResponse;
+        return hashtags;
     }
 
 
+    // 특정 강의 조회
+    public LectureResponse getLecture(long lectureId){
+        LectureResponse lectureResponse = new LectureResponse();
+        Optional<Lecture> optionalLecture = lectureRepository.findById(lectureId); // lecture 데이터 가져와서
+        if(optionalLecture.isEmpty())
+            return lectureResponse;
+        Lecture lecture = optionalLecture.get();
+        lectureResponse.setLectureId(lecture.getLectureId());
+        lectureResponse.setLectureTitle(lecture.getLectureTitle());
+        lectureResponse.setLecturer(lecture.getLecturer());
+        lectureResponse.setSiteName(lecture.getSiteName());
+        lectureResponse.setLectureUrl(lecture.getLectureUrl());
+        lectureResponse.setThumbnailUrl(lecture.getThumbnailUrl());
+
+        List<Review> reviews = reviewRepository.findByLecture(lecture); // lecture 를 갖고 reviews 에 있는 모든 데이터 가져오기
+        int reviewCnt = reviews.size();
+        lectureResponse.setReviewCnt(reviewCnt); // 리뷰 개수 세팅
+
+        int totalRate=0;
+        List<ReviewOnlyDto> reviewOnlyDtos = new ArrayList<>();
+        for(int i=0;i<reviews.size();i++){ // 특정 강의에 해당하는 리뷰들을 찾기 위해서
+            ReviewOnlyDto reviewOnlyDto = new ReviewOnlyDto();
+            BeanUtils.copyProperties(reviews.get(i), reviewOnlyDto,"reviewHashtags"); // 원본 객체, 복사 대상 객체
+            String nickname = reviews.get(i).getUser().getUserNickname();
+            reviewOnlyDto.setNickname(nickname);
+            reviewOnlyDtos.add(reviewOnlyDto);
+            totalRate += reviews.get(i).getRate();
+        }
+        lectureResponse.setReviews(reviewOnlyDtos);
+        lectureResponse.setHashtags(getBestHashtags(lecture)); // 특정 Lecture에 해당하는 해시태그 상위 3개 가져오는 함수 호출
+        lectureResponse.setAvgRate(totalRate/reviews.size()); // 평균 점수 계산
+
+        List<Like> likes = likeRepository.findLikeByLecture(lecture);
+        lectureResponse.setLikeCnt(likes.size());
+        return lectureResponse;
+    }
 
 
     // url 중복 조회용

--- a/src/main/java/com/example/demo/service/LikeService.java
+++ b/src/main/java/com/example/demo/service/LikeService.java
@@ -1,5 +1,6 @@
 package com.example.demo.service;
 
+import com.example.demo.domain.Lecture;
 import com.example.demo.domain.Like;
 import com.example.demo.domain.StudyPost;
 import com.example.demo.domain.User;
@@ -18,15 +19,29 @@ import java.util.Optional;
 public class LikeService {
     private final LikeRepository likeRepository;
 
-    public void saveInterest(Like like){
+    public void saveLike(Like like){
         likeRepository.save(like);
     }
 
-    public Like findInterestById(Long id){
-        Optional<Like> interest = likeRepository.findById(id);
-        return interest.orElse(null);
-
+    public Like findLikeById(Long id){
+        Optional<Like> like = likeRepository.findById(id);
+        return like.orElse(null);
     }
+
+    // 특정 유저가 특정 강의에 좋아요 누른지 확인
+    public Like findLikeByLectureAndUser(Lecture lecture, User user){
+        Optional<Like> like = likeRepository.findLikeByLectureAndUser(lecture, user);
+        return like.orElse(null);
+    }
+
+    // 좋아요 상태 변경하기
+    public int changeLikeStatus(Like lectureLike, int likeStatus){
+        if(likeStatus==0) // 취소한 상태에서 다시 누른 경우
+            return likeRepository.updateLikeStatus(lectureLike, likeStatus+1);
+        else // 좋아요 누른 상태에서 취소하는 경우
+            return likeRepository.updateLikeStatus(lectureLike, likeStatus-1);
+    }
+
 
     //studyPost와 user로 찾는게 있어야함
     public Like findLikeByStudyPostandUser(StudyPost post, User user){


### PR DESCRIPTION
### 전달사항

1. 로드맵에서 '강의리뷰' 에서 사용한 강의 조회 함수/ 해시태그 가져오기 함수 2개를 재사용할 수 있을 거라 생각했는데 
결론은 해시태그 함수만 재사용 가능

특정 유저가 리뷰 남긴 강의 모두 가져오기 (제목)
-> 얘는 유저랑 강의에 해당하는 객체들을 찾아오는 함수가 애초에 없어서 재사용 불가 

해당 강의의 해시태그 3개 가져오기 
-> 얘는 LectureService 에 함수로 빼놨슴다 - getBestHashtags() 

2. 신고도 division 불필요
