### PR TITLE
[FEAT] 로드맵 좋아요, 수정, 삭제 API

### DIFF
--- a/src/main/java/com/example/demo/like/Like.java
+++ b/src/main/java/com/example/demo/like/Like.java
@@ -56,4 +56,10 @@ public class Like {
         this.lecture = lecture;
         this.user = user;
     }
+
+    @Builder
+    public Like(RoadMap roadMap, User user) {
+        this.roadmap=roadMap;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/example/demo/like/LikeService.java
+++ b/src/main/java/com/example/demo/like/LikeService.java
@@ -66,8 +66,5 @@ public class LikeService {
         return likesOnRoadmap.size();
     }
 
-    public void changeLikeOnRoadmapByGroup(Integer roadmapGroupId, Integer likeStatus){
-        likeRepository.updateLikeStatusOnRoadmap(roadmapGroupId,likeStatus);
-    }
 
 }

--- a/src/main/java/com/example/demo/like/LikeService.java
+++ b/src/main/java/com/example/demo/like/LikeService.java
@@ -66,4 +66,8 @@ public class LikeService {
         return likesOnRoadmap.size();
     }
 
+    public void changeLikeOnRoadmapByGroup(Integer roadmapGroupId, Integer likeStatus){
+        likeRepository.updateLikeStatusOnRoadmap(roadmapGroupId,likeStatus);
+    }
+
 }

--- a/src/main/java/com/example/demo/like/repository/CustomLikeRepository.java
+++ b/src/main/java/com/example/demo/like/repository/CustomLikeRepository.java
@@ -12,4 +12,5 @@ public interface CustomLikeRepository {
     List<Like> findLikeByLecture(Lecture lecture); // 강의글 좋아요 가져오기
     List<Like> findLikeByStudyPost(StudyPost post);
     List<Like> findLikeByRoadMap(RoadMap roadMap);
+    Integer updateLikeStatusOnRoadmap(Integer roadmapGroupId, Integer likeStatus);
 }

--- a/src/main/java/com/example/demo/like/repository/CustomLikeRepository.java
+++ b/src/main/java/com/example/demo/like/repository/CustomLikeRepository.java
@@ -12,5 +12,4 @@ public interface CustomLikeRepository {
     List<Like> findLikeByLecture(Lecture lecture); // 강의글 좋아요 가져오기
     List<Like> findLikeByStudyPost(StudyPost post);
     List<Like> findLikeByRoadMap(RoadMap roadMap);
-    Integer updateLikeStatusOnRoadmap(Integer roadmapGroupId, Integer likeStatus);
 }

--- a/src/main/java/com/example/demo/like/repository/CustomLikeRepositoryImpl.java
+++ b/src/main/java/com/example/demo/like/repository/CustomLikeRepositoryImpl.java
@@ -50,4 +50,14 @@ public class CustomLikeRepositoryImpl implements CustomLikeRepository{
                 .where(like.roadmap.eq(roadMap),like.likeStatus.eq(1))
                 .fetch();
     }
+
+    @Override
+    public Integer updateLikeStatusOnRoadmap(Integer roadmapGroupId, Integer likeStatus) {
+        jpaQueryFactory
+                .update(like)
+                .set(like.likeStatus,likeStatus)
+                .where(like.roadmap.roadmapGroupId.eq(roadmapGroupId)) // groupId 에러 해결
+                .execute();
+        return likeStatus;
+    }
 }

--- a/src/main/java/com/example/demo/like/repository/CustomLikeRepositoryImpl.java
+++ b/src/main/java/com/example/demo/like/repository/CustomLikeRepositoryImpl.java
@@ -51,13 +51,4 @@ public class CustomLikeRepositoryImpl implements CustomLikeRepository{
                 .fetch();
     }
 
-    @Override
-    public Integer updateLikeStatusOnRoadmap(Integer roadmapGroupId, Integer likeStatus) {
-        jpaQueryFactory
-                .update(like)
-                .set(like.likeStatus,likeStatus)
-                .where(like.roadmap.roadmapGroupId.eq(roadmapGroupId)) // groupId 에러 해결
-                .execute();
-        return likeStatus;
-    }
 }

--- a/src/main/java/com/example/demo/roadmap/RoadMap.java
+++ b/src/main/java/com/example/demo/roadmap/RoadMap.java
@@ -67,4 +67,8 @@ public class RoadMap {
         this.user=user;
     }
 
+    public void updateRoadmapLectureOrder(Integer order){
+        this.roadmapLectureOrder=order;
+    }
+
 }

--- a/src/main/java/com/example/demo/roadmap/RoadMapService.java
+++ b/src/main/java/com/example/demo/roadmap/RoadMapService.java
@@ -70,7 +70,7 @@ public class RoadMapService {
             BeanUtils.copyProperties(lecture,lectureResponse);
             lectureResponse.setLectureHashtags(lectureService.getBestHashtags(lecture));
             lectureResponse.setLectureAvgRate(lectureService.getAvgRate(lecture));
-            Review review=reviewService.findByUserAndLecture(user,lecture);
+            Review review=reviewService.findByUserAndLecture(roadmapWriter,lecture);
             lectureResponse.setLectureReviewTitle(review.getCommentTitle());
             lectureResponse.setLectureReviewContent(review.getComment());
             lectures.add(lectureResponse);

--- a/src/main/java/com/example/demo/roadmap/RoadMapService.java
+++ b/src/main/java/com/example/demo/roadmap/RoadMapService.java
@@ -51,8 +51,7 @@ public class RoadMapService {
 
     //로드맵 그룹아이디를 기반으로 하나의 로드맵을 찾아옴 -> order 순서대로 오름차순 정렬
     public List<RoadMap> getAllRoadMapsByGroup(Integer roadmapGroupId){
-        List<RoadMap> roadmaps=roadMapRepository.findAllRoadmapsByGroupId(roadmapGroupId);
-        return roadmaps;
+        return roadMapRepository.findAllRoadmapsByGroupId(roadmapGroupId);
     }
 
     public DetailRoadmapResponse getDetailRoadmapResponse(List<RoadMap> originRoadmaps, User user){
@@ -83,6 +82,12 @@ public class RoadMapService {
     public Boolean getUserRoadmapLikedStatus(RoadMap roadmap,User user){
         Like like=likeService.findLikeByRoadmapAndUser(roadmap,user);
         return like != null && like.getLikeStatus() == 1;
+    }
+
+    public RoadMap getRoadmapByLectureIdAndGroup(Long lectureId, Integer groupId){
+        Lecture lecture=lectureService.findById(lectureId);
+        Optional<RoadMap> roadmap=roadMapRepository.findByRoadmapGroupIdAndLecture(groupId,lecture);
+        return roadmap.orElse(null); //0인지 1인지 체크는 controller 에서 하도록
     }
 
 

--- a/src/main/java/com/example/demo/roadmap/RoadMapService.java
+++ b/src/main/java/com/example/demo/roadmap/RoadMapService.java
@@ -41,14 +41,12 @@ public class RoadMapService {
         return maxGroupId!=null?maxGroupId:0; //만약 테이블이 비어있으면 null이 return -> 그럴 경우 0을 return
     }
 
-    public RoadMap getRoadMapById(Long roadmapId){
-        Optional<RoadMap> roadMap = roadMapRepository.findById(roadmapId);
-        if(roadMap.isPresent()){
-            RoadMap map=roadMap.get();
-            return map.getRoadmapStatus()==1?map:null;
-        }else{
+    public RoadMap getFirstRoadMapByGroupId(Integer groupId){
+        List<RoadMap> roadmaps = roadMapRepository.findAllRoadmapsByGroupId(groupId);
+        if(roadmaps.isEmpty())
             return null;
-        }
+        else
+            return roadmaps.get(0);
     }
 
     //로드맵 그룹아이디를 기반으로 하나의 로드맵을 찾아옴 -> order 순서대로 오름차순 정렬
@@ -85,8 +83,8 @@ public class RoadMapService {
     public Boolean getUserRoadmapLikedStatus(RoadMap roadmap,User user){
         Like like=likeService.findLikeByRoadmapAndUser(roadmap,user);
         return like != null && like.getLikeStatus() == 1;
-
     }
+
 
 
 

--- a/src/main/java/com/example/demo/roadmap/dto/DetailRoadmapResponse.java
+++ b/src/main/java/com/example/demo/roadmap/dto/DetailRoadmapResponse.java
@@ -9,6 +9,7 @@ import java.util.List;
 @Getter
 @Setter
 public class DetailRoadmapResponse {
+    private Integer roadmapGroupId;
     private String roadmapTitle;
     private String roadmapRecommendation;
     private Integer likeCount;

--- a/src/main/java/com/example/demo/roadmap/repository/CustomRoadMapRepositoryImpl.java
+++ b/src/main/java/com/example/demo/roadmap/repository/CustomRoadMapRepositoryImpl.java
@@ -30,7 +30,7 @@ public class CustomRoadMapRepositoryImpl implements CustomRoadMapRepository{
     public List<RoadMap> findAllRoadmapsByGroupId(Integer groupId) {
         List<RoadMap> roadmaps=jpaQueryFactory
                 .selectFrom(roadMap)
-                .where(roadMap.roadmapGroupId.eq(groupId))
+                .where(roadMap.roadmapGroupId.eq(groupId),roadMap.roadmapStatus.eq(1))
                 .orderBy(roadMap.roadmapLectureOrder.asc())
                 .fetch();
         return roadmaps;

--- a/src/main/java/com/example/demo/roadmap/repository/RoadMapRepository.java
+++ b/src/main/java/com/example/demo/roadmap/repository/RoadMapRepository.java
@@ -1,9 +1,13 @@
 package com.example.demo.roadmap.repository;
 
+import com.example.demo.lecture.Lecture;
 import com.example.demo.roadmap.RoadMap;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface RoadMapRepository extends JpaRepository<RoadMap,Long>,CustomRoadMapRepository {
+    Optional<RoadMap> findByRoadmapGroupIdAndLecture(Integer groupId, Lecture lecture);
 }

--- a/src/main/java/com/example/demo/roadmap/roadMapController.java
+++ b/src/main/java/com/example/demo/roadmap/roadMapController.java
@@ -106,7 +106,11 @@ public class roadMapController {
             }
             return new ResponseEntity<>(new ResponseMessage(201,"좋아요가 등록되었습니다."),HttpStatus.CREATED);
         }else{
-            likeService.changeLikeOnRoadmapByGroup(roadmapGroupId,foundLike.getLikeStatus()==1?0:1); //좋아요 눌린 상태면 0으로, 아니면 1로
+            for(RoadMap map:roadmaps){
+                Like like=likeService.findLikeByRoadmapAndUser(map,user);
+                like.setLikeStatus(like.getLikeStatus()==1?0:1);
+                likeService.saveLike(like);
+            }
             return new ResponseEntity<>(new ResponseMessage(200,"좋아요 상태 변경 성공"),HttpStatus.OK);
         }
     }

--- a/src/main/java/com/example/demo/roadmap/roadMapController.java
+++ b/src/main/java/com/example/demo/roadmap/roadMapController.java
@@ -200,4 +200,20 @@ public class roadMapController {
 
     }
 
+    @DeleteMapping("/roadmaps/{roadmapGroupId}")
+    public ResponseEntity<ResponseMessage> deleteRoadmap(@PathVariable Integer roadmapGroupId,Principal principal){
+        String email=principal.getName();
+        List<RoadMap> roadMaps=roadMapService.getAllRoadMapsByGroup(roadmapGroupId);
+        if(roadMaps.isEmpty())
+            return new ResponseEntity<>(new ResponseMessage(404,"존재하지 않는 로드맵에 대한 삭제 요청입니다."),HttpStatus.OK);
+        String writerEmail=roadMaps.get(0).getUser().getUserEmail();
+        if(!email.equals(writerEmail))
+            return new ResponseEntity<>(new ResponseMessage(403,roadmapGroupId+"번 로드맵에 삭제 권한이 없는 사용자 입니다."),HttpStatus.OK);
+        for(RoadMap roadMap:roadMaps){
+            roadMap.setRoadmapStatus(0);
+            roadMapService.saveRoadmap(roadMap);
+        }
+        return new ResponseEntity<>(new ResponseMessage(200, roadmapGroupId+"번 로드맵 삭제 성공"),HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/example/demo/roadmap/roadMapController.java
+++ b/src/main/java/com/example/demo/roadmap/roadMapController.java
@@ -85,21 +85,8 @@ public class roadMapController {
         if(roadmaps.isEmpty()){
             return new ResponseEntity<>(new ResponseMessage(404,"존재하지 않는 로드맵에 대한 요청입니다."),HttpStatus.OK);
         }
-        System.out.print("likes: ");
-        for(RoadMap map:roadmaps){
-            List<Like> likes = map.getLikes();
-            int count=0;
-            for(Like like:likes){
-                count+=like.getLikeStatus()==1?1:0;
-            }
-            System.out.print(count+" ");
-        }
-        System.out.println();
+
         DetailRoadmapResponse detailRoadmapResponse = roadMapService.getDetailRoadmapResponse(roadmaps, user);
-        System.out.print("lectures: ");
-        for(DetailRoadmapLectureResponse lec:detailRoadmapResponse.getLectures()){
-            System.out.print(lec.getLectureId()+" ");
-        }
 
         return new ResponseEntity<>(ResponseMessage.withData(200,"상세 로드맵 조회 성공",detailRoadmapResponse),HttpStatus.OK);
     }
@@ -210,14 +197,6 @@ public class roadMapController {
         }
 
         return new ResponseEntity<>(new ResponseMessage(200,"로드맵이 수정 성공"),HttpStatus.OK);
-        //roadmaps 에 남은 로드맵들은 사용자가 삭제한 내용들이므로 db에서 제거, changedLectureIds에 남은 것들은 새롭게 디비에 추가해야할 것들
-
-        //원래 저장되어 있는 로드맵 리스트를 먼저 수정 -> 순서만 바뀐거면? save, 아예 사라진거면?(roadmapDto에 동일한 lectureid가 없다면) db에서 삭제
-        //roadmapDto에서 기존 로드맵이랑 lectureid가 일치해서 변경사항이 반영된 애들은 제거
-        //이후, roadmapDto에서 남은 lectureid list에 대해서 roadmap에 새롭게 저장
-        //1. groupId를 기반으로 기존의 로드맵 전체 데이터를 찾는다
-        //2. roadmapDto에 넘어온 list 데이터와 2에서 찾은 전체 데이터의 lectureId를 비교, 일치하는 값에 대해서는 반영
-        //3. ㄹㅇㄴ릉으응ㅁ 아예 근야 기존 데이터 다 지우고 새롭게 groupId 기반으로 데이터 저장! -> 에반데 흐으으음....
 
     }
 


### PR DESCRIPTION
로드맵 수정 시
1. 기존 로드맵에서 순서가 바뀐 강의들: 순서만 변경
2. 기존 로드맵에 있었지만, 수정된 로드맵에서는 삭제된 강의들: status 0으로 세팅
3. 기존 로드맵에 없었지만 수정된 로드맵에서 새롭게 추가된 강의들
   1) status가 0인 강의가 존재한다면? status 1로 세팅, 변경된 제목과 추천대상 update
   2) 데이터베이스에 해당 로드맵의 강의가 없었다면? 새롭게 로드맵 데이터 추가
   3) 새롭게 로드맵 데이터가 추가 및 상태가 1로 변경되는 경우, 기존의 로드맵 좋아요 내역들을 모두 동일하게 반영시킴